### PR TITLE
fix: disable locking for now

### DIFF
--- a/src/data/persistence.ts
+++ b/src/data/persistence.ts
@@ -169,6 +169,9 @@ ${instanceId}`
 export class LockError extends Error {}
 
 async function verifyLock(workspaceDir: FileSystemDirectoryHandle) {
+  if (true) {
+    return // Locking is currently disabled, see https://github.com/scope42/scope42/issues/186
+  }
   let fileHandle: FileSystemFileHandle
   try {
     fileHandle = await workspaceDir.getFileHandle(LOCK_FILE)
@@ -187,6 +190,9 @@ async function verifyLock(workspaceDir: FileSystemDirectoryHandle) {
 }
 
 async function claimLock(workspaceDir: FileSystemDirectoryHandle) {
+  if (true) {
+    return // Locking is currently disabled, see https://github.com/scope42/scope42/issues/186
+  }
   const fileHandle = await workspaceDir.getFileHandle(LOCK_FILE, {
     create: true
   })


### PR DESCRIPTION
In practice, this turned out to be a bad UX,
mainly because having to deal with merge conflicts.
Also, it is bad that write access is required even when only reading.