### PR TITLE
feat(cli): add @scope42/cli with scope42 lint and scope42 init commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,6 @@ yarn-error.log*
 
 .claude
 superpowers/
+specs/
+plans/
 CLAUDE.local.md

--- a/app/example/export.ts
+++ b/app/example/export.ts
@@ -1,5 +1,5 @@
 import { Workspace } from '@scope42/data'
-import { NodeDirectoryHandle } from '@scope42/data/dist/io/adapters/node'
+import { NodeDirectoryHandle } from '@scope42/data/node'
 import superjson from 'superjson'
 import fs from 'fs'
 

--- a/examples/data-processing/src/index.ts
+++ b/examples/data-processing/src/index.ts
@@ -1,5 +1,5 @@
 import { Workspace } from '@scope42/data'
-import { NodeDirectoryHandle } from '@scope42/data/dist/io/adapters/node'
+import { NodeDirectoryHandle } from '@scope42/data/node'
 
 const workspace = new Workspace(new NodeDirectoryHandle('../../example'))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4187,6 +4187,10 @@
       "resolved": "app",
       "link": true
     },
+    "node_modules/@scope42/cli": {
+      "resolved": "packages/scope42-cli",
+      "link": true
+    },
     "node_modules/@scope42/data": {
       "resolved": "packages/scope42-data",
       "link": true
@@ -26625,6 +26629,56 @@
         "eslint-config-react-app": "7.0.1",
         "eslint-config-turbo": "0.0.9",
         "eslint-plugin-prettier": "4.2.1"
+      }
+    },
+    "packages/scope42-cli": {
+      "name": "@scope42/cli",
+      "version": "0.0.0",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "@scope42/data": "*",
+        "commander": "^12.0.0"
+      },
+      "bin": {
+        "scope42": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@scope42/tsconfig": "*",
+        "@types/jest": "29.4.0",
+        "@types/node": "^18.0.0",
+        "@xinra/prettier-config": "2.0.0",
+        "eslint": "8.35.0",
+        "eslint-config-scope42": "*",
+        "jest": "29.5.0",
+        "prettier": "2.8.1",
+        "ts-jest": "29.0.5",
+        "tsup": "6.6.3",
+        "typescript": "4.9.5"
+      }
+    },
+    "packages/scope42-cli/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/scope42-cli/node_modules/prettier": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/scope42-data": {

--- a/packages/scope42-cli/.eslintrc.js
+++ b/packages/scope42-cli/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['scope42']
+}

--- a/packages/scope42-cli/jest.config.js
+++ b/packages/scope42-cli/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node'
+}

--- a/packages/scope42-cli/jest.config.js
+++ b/packages/scope42-cli/jest.config.js
@@ -1,5 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  passWithNoTests: true
 }

--- a/packages/scope42-cli/package.json
+++ b/packages/scope42-cli/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@scope42/cli",
+  "version": "0.0.0",
+  "license": "GPL-3.0-only",
+  "bin": {
+    "scope42": "./dist/cli.js"
+  },
+  "files": ["dist/**"],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "lint": "eslint \"src/**/*.ts*\"",
+    "test": "jest"
+  },
+  "prettier": "@xinra/prettier-config",
+  "devDependencies": {
+    "@scope42/tsconfig": "*",
+    "@types/jest": "29.4.0",
+    "@types/node": "^18.0.0",
+    "@xinra/prettier-config": "2.0.0",
+    "eslint": "8.35.0",
+    "eslint-config-scope42": "*",
+    "jest": "29.5.0",
+    "prettier": "2.8.1",
+    "ts-jest": "29.0.5",
+    "tsup": "6.6.3",
+    "typescript": "4.9.5"
+  },
+  "dependencies": {
+    "@scope42/data": "*",
+    "commander": "^12.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/scope42-cli/src/cli.ts
+++ b/packages/scope42-cli/src/cli.ts
@@ -1,0 +1,7 @@
+import { Command } from 'commander'
+
+const program = new Command()
+
+program.name('scope42').description('scope42 CLI').version('0.0.0')
+
+program.parseAsync(process.argv)

--- a/packages/scope42-cli/src/cli.ts
+++ b/packages/scope42-cli/src/cli.ts
@@ -1,10 +1,12 @@
 import { Command } from 'commander'
 import { makeInitCommand } from './commands/init'
+import { makeLintCommand } from './commands/lint'
 
 const program = new Command()
 
 program.name('scope42').description('scope42 CLI').version('0.0.0')
 
 program.addCommand(makeInitCommand())
+program.addCommand(makeLintCommand())
 
 program.parseAsync(process.argv)

--- a/packages/scope42-cli/src/cli.ts
+++ b/packages/scope42-cli/src/cli.ts
@@ -1,7 +1,10 @@
 import { Command } from 'commander'
+import { makeInitCommand } from './commands/init'
 
 const program = new Command()
 
 program.name('scope42').description('scope42 CLI').version('0.0.0')
+
+program.addCommand(makeInitCommand())
 
 program.parseAsync(process.argv)

--- a/packages/scope42-cli/src/commands/init.test.ts
+++ b/packages/scope42-cli/src/commands/init.test.ts
@@ -25,4 +25,8 @@ test('returns 0 with --force even when file exists', async () => {
   const root = ws({ 'scope42.yaml': 'old: content\n' })
   const exitCode = await runInit(root, { force: true }, () => {})
   expect(exitCode).toBe(0)
+  const file = await root.resolveFile('scope42.yaml')
+  const text = await file.readText()
+  expect(text).toContain('version: 2')
+  expect(text).not.toContain('old: content')
 })

--- a/packages/scope42-cli/src/commands/init.test.ts
+++ b/packages/scope42-cli/src/commands/init.test.ts
@@ -1,0 +1,28 @@
+import { runInit } from './init'
+import { VirtualDirectoryHandle, VirtualDirectoryContent } from '@scope42/data'
+
+function ws(content: VirtualDirectoryContent) {
+  return new VirtualDirectoryHandle('root', content)
+}
+
+test('returns 0 and creates scope42.yaml', async () => {
+  const root = ws({})
+  const lines: string[] = []
+  const exitCode = await runInit(root, {}, (s: string) => lines.push(s))
+  expect(exitCode).toBe(0)
+  const file = await root.resolveFile('scope42.yaml')
+  const text = await file.readText()
+  expect(text).toContain('version: 2')
+})
+
+test('returns 1 when scope42.yaml already exists', async () => {
+  const root = ws({ 'scope42.yaml': 'version: 2\n' })
+  const exitCode = await runInit(root, {}, () => {})
+  expect(exitCode).toBe(1)
+})
+
+test('returns 0 with --force even when file exists', async () => {
+  const root = ws({ 'scope42.yaml': 'old: content\n' })
+  const exitCode = await runInit(root, { force: true }, () => {})
+  expect(exitCode).toBe(0)
+})

--- a/packages/scope42-cli/src/commands/init.ts
+++ b/packages/scope42-cli/src/commands/init.ts
@@ -1,0 +1,32 @@
+import { Command } from 'commander'
+import path from 'path'
+import { DirectoryHandle, initWorkspace } from '@scope42/data'
+import { NodeDirectoryHandle } from '@scope42/data/node'
+
+export function makeInitCommand(): Command {
+  return new Command('init')
+    .description('Initialize a new scope42 workspace')
+    .argument('[path]', 'Path to the workspace root', '.')
+    .option('--force', 'Overwrite existing scope42.yaml')
+    .action(async (workspacePath: string, options: { force?: boolean }) => {
+      const absPath = path.resolve(workspacePath)
+      const rootDir = new NodeDirectoryHandle(absPath)
+      const exitCode = await runInit(rootDir, options)
+      if (exitCode !== 0) process.exit(exitCode)
+    })
+}
+
+export async function runInit(
+  rootDir: DirectoryHandle,
+  options: { force?: boolean },
+  out: (line: string) => void = s => process.stdout.write(s + '\n')
+): Promise<number> {
+  try {
+    await initWorkspace(rootDir, options)
+    out('Created scope42.yaml')
+    return 0
+  } catch (e) {
+    out(`Error: ${(e as Error).message}`)
+    return 1
+  }
+}

--- a/packages/scope42-cli/src/commands/init.ts
+++ b/packages/scope42-cli/src/commands/init.ts
@@ -26,7 +26,7 @@ export async function runInit(
     out('Created scope42.yaml')
     return 0
   } catch (e) {
-    out(`Error: ${(e as Error).message}`)
+    out(`Error: ${e instanceof Error ? e.message : String(e)}`)
     return 1
   }
 }

--- a/packages/scope42-cli/src/commands/lint.test.ts
+++ b/packages/scope42-cli/src/commands/lint.test.ts
@@ -1,0 +1,106 @@
+import { runLint } from './lint'
+import { VirtualDirectoryHandle, VirtualDirectoryContent } from '@scope42/data'
+
+function ws(content: VirtualDirectoryContent) {
+  return new VirtualDirectoryHandle('root', content)
+}
+
+const CLEAN_CFG = `
+version: 2
+items:
+  issue: docs/issues
+  risk: docs/risks
+include: ["*.md"]
+`
+
+test('returns 0 for a clean workspace (no errors, no warnings)', async () => {
+  // Both items have relations pointing to each other — no orphan warnings
+  const root = ws({
+    'scope42.yaml': CLEAN_CFG,
+    docs: {
+      issues: {
+        'issue-1.md':
+          '---\nstatus: current\ncausedBy: ["risk-1"]\n---\n# Issue\n\nBody.\n'
+      },
+      risks: {
+        'risk-1.md':
+          '---\nstatus: potential\ncausedBy: ["issue-1"]\n---\n# Risk\n\nBody.\n'
+      }
+    }
+  })
+  const exitCode = await runLint(root, 'text', () => {})
+  expect(exitCode).toBe(0)
+})
+
+test('returns 1 for a workspace with only warnings', async () => {
+  // Valid item but orphaned (no relations) → warning
+  const root = ws({
+    'scope42.yaml': `
+version: 2
+items:
+  issue: docs/issues
+include: ["*.md"]
+`,
+    docs: {
+      issues: { 'issue-1.md': '---\nstatus: current\n---\n# Title\n\nBody.\n' }
+    }
+  })
+  const exitCode = await runLint(root, 'text', () => {})
+  expect(exitCode).toBe(1)
+})
+
+test('returns 2 for a workspace with errors', async () => {
+  const root = ws({
+    'scope42.yaml': `
+version: 2
+items:
+  issue: docs/issues
+include: ["*.md"]
+`,
+    docs: {
+      issues: {
+        'issue-1.md': '---\nstatus: bogus\n---\n# Title\n\nBody.\n'
+      }
+    }
+  })
+  const exitCode = await runLint(root, 'text', () => {})
+  expect(exitCode).toBe(2)
+})
+
+test('text format includes file path in output', async () => {
+  const root = ws({
+    'scope42.yaml': `
+version: 2
+items:
+  issue: docs/issues
+include: ["*.md"]
+`,
+    docs: {
+      issues: {
+        'issue-1.md': '---\nstatus: bogus\n---\n# Title\n\nBody.\n'
+      }
+    }
+  })
+  const lines: string[] = []
+  await runLint(root, 'text', (s: string) => lines.push(s))
+  expect(lines.some(l => l.includes('issue-1.md'))).toBe(true)
+})
+
+test('json format outputs valid JSON with diagnostics array', async () => {
+  const root = ws({
+    'scope42.yaml': `
+version: 2
+items:
+  issue: docs/issues
+include: ["*.md"]
+`,
+    docs: {
+      issues: { 'issue-1.md': '---\nstatus: current\n---\n# Title\n\nBody.\n' }
+    }
+  })
+  const lines: string[] = []
+  await runLint(root, 'json', (s: string) => lines.push(s))
+  const parsed = JSON.parse(lines.join('\n'))
+  expect(parsed).toHaveProperty('diagnostics')
+  expect(Array.isArray(parsed.diagnostics)).toBe(true)
+})

--- a/packages/scope42-cli/src/commands/lint.test.ts
+++ b/packages/scope42-cli/src/commands/lint.test.ts
@@ -104,3 +104,11 @@ include: ["*.md"]
   expect(parsed).toHaveProperty('diagnostics')
   expect(Array.isArray(parsed.diagnostics)).toBe(true)
 })
+
+test('returns 2 and reports error when workspace config is missing', async () => {
+  const root = ws({}) // no scope42.yaml → lintWorkspace throws
+  const lines: string[] = []
+  const exitCode = await runLint(root, 'text', (s: string) => lines.push(s))
+  expect(exitCode).toBe(2)
+  expect(lines.some(l => l.startsWith('Error:'))).toBe(true)
+})

--- a/packages/scope42-cli/src/commands/lint.ts
+++ b/packages/scope42-cli/src/commands/lint.ts
@@ -12,7 +12,7 @@ export function makeLintCommand(): Command {
       const absPath = path.resolve(workspacePath)
       const rootDir = new NodeDirectoryHandle(absPath)
       const exitCode = await runLint(rootDir, options.format as 'text' | 'json')
-      process.exit(exitCode)
+      if (exitCode !== 0) process.exit(exitCode)
     })
 }
 

--- a/packages/scope42-cli/src/commands/lint.ts
+++ b/packages/scope42-cli/src/commands/lint.ts
@@ -1,0 +1,50 @@
+import { Command } from 'commander'
+import path from 'path'
+import { DirectoryHandle, LintResult, lintWorkspace } from '@scope42/data'
+import { NodeDirectoryHandle } from '@scope42/data/node'
+
+export function makeLintCommand(): Command {
+  return new Command('lint')
+    .description('Validate all scope42 items in a workspace')
+    .argument('[path]', 'Path to the workspace root', '.')
+    .option('--format <format>', 'Output format: text or json', 'text')
+    .action(async (workspacePath: string, options: { format: string }) => {
+      const absPath = path.resolve(workspacePath)
+      const rootDir = new NodeDirectoryHandle(absPath)
+      const exitCode = await runLint(rootDir, options.format as 'text' | 'json')
+      process.exit(exitCode)
+    })
+}
+
+export async function runLint(
+  rootDir: DirectoryHandle,
+  format: 'text' | 'json',
+  out: (line: string) => void = s => process.stdout.write(s + '\n')
+): Promise<number> {
+  let result: LintResult
+  try {
+    result = await lintWorkspace(rootDir)
+  } catch (e) {
+    out(`Error: ${e instanceof Error ? e.message : String(e)}`)
+    return 2
+  }
+
+  const { diagnostics } = result
+  const errors = diagnostics.filter(d => d.severity === 'error')
+  const warnings = diagnostics.filter(d => d.severity === 'warning')
+
+  if (format === 'json') {
+    out(JSON.stringify(result, null, 2))
+  } else {
+    for (const d of diagnostics) {
+      const label = d.severity === 'error' ? 'error' : 'warn'
+      out(`${d.filePath}: ${label}: ${d.message}`)
+    }
+    if (diagnostics.length > 0) out('')
+    out(`${errors.length} error(s), ${warnings.length} warning(s)`)
+  }
+
+  if (errors.length > 0) return 2
+  if (warnings.length > 0) return 1
+  return 0
+}

--- a/packages/scope42-cli/tsconfig.json
+++ b/packages/scope42-cli/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@scope42/tsconfig/library.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/packages/scope42-cli/tsup.config.ts
+++ b/packages/scope42-cli/tsup.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/cli.ts'],
+  format: ['cjs'],
+  banner: { js: '#!/usr/bin/env node' }
+})

--- a/packages/scope42-data/package.json
+++ b/packages/scope42-data/package.json
@@ -6,6 +6,24 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./node": {
+      "import": "./dist/io/adapters/node.mjs",
+      "require": "./dist/io/adapters/node.js",
+      "types": "./dist/io/adapters/node.d.ts"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      ".": ["./dist/index.d.ts"],
+      "node": ["./dist/io/adapters/node.d.ts"]
+    }
+  },
   "files": [
     "dist/**"
   ],

--- a/packages/scope42-data/package.json
+++ b/packages/scope42-data/package.json
@@ -43,7 +43,8 @@
       "esm",
       "cjs"
     ],
-    "dts": true
+    "dts": true,
+    "clean": true
   },
   "prettier": "@xinra/prettier-config",
   "devDependencies": {

--- a/packages/scope42-data/package.json
+++ b/packages/scope42-data/package.json
@@ -13,15 +13,15 @@
       "types": "./dist/index.d.ts"
     },
     "./node": {
-      "import": "./dist/io/adapters/node.mjs",
-      "require": "./dist/io/adapters/node.js",
-      "types": "./dist/io/adapters/node.d.ts"
+      "import": "./dist/node.mjs",
+      "require": "./dist/node.js",
+      "types": "./dist/node.d.ts"
     }
   },
   "typesVersions": {
     "*": {
       ".": ["./dist/index.d.ts"],
-      "node": ["./dist/io/adapters/node.d.ts"]
+      "node": ["./dist/node.d.ts"]
     }
   },
   "files": [
@@ -34,11 +34,11 @@
     "test": "jest"
   },
   "tsup": {
-    "entry": [
-      "src/index.ts",
-      "src/io/adapters/node.ts",
-      "src/io/adapters/fsa.ts"
-    ],
+    "entry": {
+      "index": "src/index.ts",
+      "node": "src/io/adapters/node.ts",
+      "fsa": "src/io/adapters/fsa.ts"
+    },
     "format": [
       "esm",
       "cjs"

--- a/packages/scope42-data/src/index.ts
+++ b/packages/scope42-data/src/index.ts
@@ -1,3 +1,4 @@
 export * from './model'
 export * from './io'
 export * from './init'
+export * from './lint'

--- a/packages/scope42-data/src/index.ts
+++ b/packages/scope42-data/src/index.ts
@@ -1,2 +1,3 @@
 export * from './model'
 export * from './io'
+export * from './init'

--- a/packages/scope42-data/src/init.test.ts
+++ b/packages/scope42-data/src/init.test.ts
@@ -1,0 +1,30 @@
+import { initWorkspace } from './init'
+import { VirtualDirectoryContent, VirtualDirectoryHandle } from './io/adapters'
+
+function makeRoot(content: VirtualDirectoryContent) {
+  return new VirtualDirectoryHandle('root', content)
+}
+
+test('creates scope42.yaml with default content when none exists', async () => {
+  const root = makeRoot({})
+  await initWorkspace(root)
+  const file = await root.resolveFile('scope42.yaml')
+  const text = await file.readText()
+  expect(text).toContain('version: 2')
+  expect(text).toContain('issue')
+  expect(text).toContain('docs/issues')
+})
+
+test('throws when scope42.yaml already exists', async () => {
+  const root = makeRoot({ 'scope42.yaml': 'version: 2\n' })
+  await expect(initWorkspace(root)).rejects.toThrow(/already exists/)
+})
+
+test('overwrites existing scope42.yaml when force is true', async () => {
+  const root = makeRoot({ 'scope42.yaml': 'old: content\n' })
+  await initWorkspace(root, { force: true })
+  const file = await root.resolveFile('scope42.yaml')
+  const text = await file.readText()
+  expect(text).toContain('version: 2')
+  expect(text).not.toContain('old: content')
+})

--- a/packages/scope42-data/src/init.test.ts
+++ b/packages/scope42-data/src/init.test.ts
@@ -28,3 +28,15 @@ test('overwrites existing scope42.yaml when force is true', async () => {
   expect(text).toContain('version: 2')
   expect(text).not.toContain('old: content')
 })
+
+test('creates configured item directories', async () => {
+  const root = makeRoot({})
+  await initWorkspace(root)
+  // Each configured directory should now exist
+  const docs = await root.resolveDirectory('docs')
+  await docs.resolveDirectory('issues')
+  await docs.resolveDirectory('risks')
+  await docs.resolveDirectory('improvements')
+  await docs.resolveDirectory('adrs')
+  // If no error thrown, directories exist
+})

--- a/packages/scope42-data/src/init.ts
+++ b/packages/scope42-data/src/init.ts
@@ -27,7 +27,7 @@ export async function initWorkspace(
       // file does not exist — proceed
     }
     if (exists) {
-      throw new Error(`${CONFIG_FILE} already exists. Use --force to overwrite.`)
+      throw new Error(`${CONFIG_FILE} already exists. Pass { force: true } to overwrite.`)
     }
   }
   const file = await rootDirectory.resolveOrCreateFile(CONFIG_FILE)

--- a/packages/scope42-data/src/init.ts
+++ b/packages/scope42-data/src/init.ts
@@ -1,0 +1,35 @@
+import YAML from 'yaml'
+import { DirectoryHandle } from './io/adapters'
+
+const CONFIG_FILE = 'scope42.yaml'
+
+const DEFAULT_CONFIG = {
+  version: 2,
+  items: {
+    issue: 'docs/issues',
+    risk: 'docs/risks',
+    improvement: 'docs/improvements',
+    decision: 'docs/adrs'
+  },
+  include: ['*.md', '*.adoc']
+}
+
+export async function initWorkspace(
+  rootDirectory: DirectoryHandle,
+  options: { force?: boolean } = {}
+): Promise<void> {
+  if (!options.force) {
+    let exists = false
+    try {
+      await rootDirectory.resolveFile(CONFIG_FILE)
+      exists = true
+    } catch {
+      // file does not exist — proceed
+    }
+    if (exists) {
+      throw new Error(`${CONFIG_FILE} already exists. Use --force to overwrite.`)
+    }
+  }
+  const file = await rootDirectory.resolveOrCreateFile(CONFIG_FILE)
+  await file.writeText(YAML.stringify(DEFAULT_CONFIG))
+}

--- a/packages/scope42-data/src/init.ts
+++ b/packages/scope42-data/src/init.ts
@@ -27,9 +27,19 @@ export async function initWorkspace(
       // file does not exist — proceed
     }
     if (exists) {
-      throw new Error(`${CONFIG_FILE} already exists. Pass { force: true } to overwrite.`)
+      throw new Error(
+        `${CONFIG_FILE} already exists. Pass { force: true } to overwrite.`
+      )
     }
   }
   const file = await rootDirectory.resolveOrCreateFile(CONFIG_FILE)
   await file.writeText(YAML.stringify(DEFAULT_CONFIG))
+
+  for (const dirPath of Object.values(DEFAULT_CONFIG.items)) {
+    const segments = dirPath.split('/').filter(Boolean)
+    let current: DirectoryHandle = rootDirectory
+    for (const segment of segments) {
+      current = await current.resolveOrCreateDirectory(segment)
+    }
+  }
 }

--- a/packages/scope42-data/src/lint/index.ts
+++ b/packages/scope42-data/src/lint/index.ts
@@ -1,0 +1,229 @@
+import matter from 'gray-matter'
+import picomatch from 'picomatch'
+import YAML from 'yaml'
+import {
+  DecisionFrontmatterSchema,
+  ImprovementFrontmatterSchema,
+  IssueFrontmatterSchema,
+  Item,
+  ItemType,
+  RiskFrontmatterSchema,
+  WorkspaceConfigSchema
+} from '../model'
+import { DirectoryHandle, FileHandle } from '../io/adapters'
+
+export type LintSeverity = 'error' | 'warning'
+
+export interface LintDiagnostic {
+  filePath: string
+  severity: LintSeverity
+  message: string
+}
+
+export interface LintResult {
+  diagnostics: LintDiagnostic[]
+}
+
+const SCHEMAS_BY_TYPE = {
+  issue: IssueFrontmatterSchema,
+  risk: RiskFrontmatterSchema,
+  improvement: ImprovementFrontmatterSchema,
+  decision: DecisionFrontmatterSchema
+}
+
+export async function lintWorkspace(
+  rootDirectory: DirectoryHandle
+): Promise<LintResult> {
+  const configFile = await rootDirectory.resolveFile('scope42.yaml')
+  const configText = await configFile.readText()
+  const configResult = WorkspaceConfigSchema.safeParse(
+    YAML.parse(fixYamlBackslashes(configText))
+  )
+  if (!configResult.success) {
+    throw new Error(`Invalid scope42.yaml: ${configResult.error.message}`)
+  }
+  const config = configResult.data
+
+  const diagnostics: LintDiagnostic[] = []
+  const isIncluded = makeFilter(config.include, config.exclude)
+
+  interface RawItem {
+    id: string
+    filePath: string
+    item: Item | null
+    relations: string[]
+  }
+  const rawItems: RawItem[] = []
+
+  for (const [type, dirPath] of Object.entries(config.items) as [
+    ItemType,
+    string | undefined
+  ][]) {
+    if (!dirPath) continue
+    const dir = await resolveDirByPath(rootDirectory, dirPath)
+
+    for await (const entry of dir.getContent()) {
+      if (entry.kind !== 'file') continue
+      if (!isIncluded(entry.name)) continue
+
+      const filePath = `${dirPath}/${entry.name}`
+      const id = stripExtension(entry.name)
+      const text = await (entry as FileHandle).readText()
+      const { data: rawFrontmatter, content: body } = matter(text)
+
+      let item: Item | null = null
+
+      if (Object.keys(rawFrontmatter).length === 0) {
+        diagnostics.push({ filePath, severity: 'error', message: 'No frontmatter found' })
+      } else {
+        const schema = SCHEMAS_BY_TYPE[type]
+        const parseResult = schema.safeParse(rawFrontmatter)
+        if (!parseResult.success) {
+          for (const issue of parseResult.error.issues) {
+            const fieldPath = issue.path.join('.') || type
+            diagnostics.push({
+              filePath,
+              severity: 'error',
+              message: `Invalid frontmatter: ${fieldPath} — ${issue.message}`
+            })
+          }
+        } else {
+          item = { id, type, frontmatter: parseResult.data, body, filePath } as Item
+        }
+      }
+
+      if (config.validation.fileNamePattern && !config.validation.fileNamePattern.test(id)) {
+        diagnostics.push({
+          filePath,
+          severity: 'error',
+          message: `Filename "${id}" does not match required pattern`
+        })
+      }
+
+      const headingDiag = checkHeading(body, filePath)
+      if (headingDiag) diagnostics.push(headingDiag)
+
+      if (body.trim() === '') {
+        diagnostics.push({ filePath, severity: 'warning', message: 'Empty body' })
+      }
+
+      const relations = item
+        ? extractRelations(item, config.validation.relationPattern)
+        : []
+      rawItems.push({ id, filePath, item, relations })
+    }
+  }
+
+  const allIds = new Set(rawItems.map(r => r.id))
+
+  // Build set of IDs that are referenced by at least one other item
+  const referencedIds = new Set(rawItems.flatMap(r => r.relations))
+
+  for (const { id, item, filePath, relations } of rawItems) {
+    if (!item) continue
+
+    const hasOutgoing = relations.length > 0
+    const hasIncoming = referencedIds.has(id)
+    if (!hasOutgoing && !hasIncoming) {
+      diagnostics.push({ filePath, severity: 'warning', message: 'No relations (orphaned item)' })
+    }
+
+    for (const targetId of relations) {
+      if (!allIds.has(targetId)) {
+        diagnostics.push({
+          filePath,
+          severity: 'error',
+          message: `Relation target "${targetId}" does not exist`
+        })
+      }
+    }
+  }
+
+  return { diagnostics }
+}
+
+function checkHeading(body: string, filePath: string): LintDiagnostic | null {
+  const firstNonBlank = body.split('\n').find(l => l.trim() !== '')
+  if (!firstNonBlank) return null // empty body is a separate warning
+  if (/^#\s+\S/.test(firstNonBlank) || /^=\s+\S/.test(firstNonBlank)) return null
+  return {
+    filePath,
+    severity: 'error',
+    message: 'Body does not start with a heading (expected Markdown # or AsciiDoc =)'
+  }
+}
+
+function extractRelations(item: Item, relationPattern?: RegExp): string[] {
+  const raw: string[] = []
+  switch (item.type) {
+    case 'issue':
+    case 'risk':
+      raw.push(...item.frontmatter.causedBy)
+      break
+    case 'improvement':
+      raw.push(
+        ...item.frontmatter.resolves,
+        ...item.frontmatter.modifies,
+        ...item.frontmatter.creates
+      )
+      break
+    case 'decision':
+      if (item.frontmatter.supersededBy) raw.push(item.frontmatter.supersededBy)
+      raw.push(...item.frontmatter.assesses)
+      break
+  }
+  if (!relationPattern) return raw
+  return raw.flatMap(v => {
+    const match = v.match(relationPattern)
+    return match ? [match[1]] : []
+  })
+}
+
+function makeFilter(include: string[], exclude: string[]): (name: string) => boolean {
+  const includeMatch = picomatch(include)
+  const excludeMatch = exclude.length > 0 ? picomatch(exclude) : () => false
+  return name => includeMatch(name) && !excludeMatch(name)
+}
+
+async function resolveDirByPath(root: DirectoryHandle, relPath: string): Promise<DirectoryHandle> {
+  const segments = relPath.split('/').filter(Boolean)
+  let current = root
+  for (const segment of segments) {
+    try {
+      current = await current.resolveDirectory(segment)
+    } catch {
+      throw new Error(`Configured path does not exist: ${relPath}`)
+    }
+  }
+  return current
+}
+
+function stripExtension(name: string): string {
+  const dot = name.lastIndexOf('.')
+  return dot > 0 ? name.slice(0, dot) : name
+}
+
+/**
+ * Pre-process YAML text to fix invalid backslash escape sequences in
+ * double-quoted strings. The YAML spec only allows specific escape sequences
+ * (e.g. \\n, \\t, \\\\); unrecognized sequences like \\d throw a parse error.
+ * This is common when regex patterns are written in double-quoted YAML strings
+ * without doubling the backslash. We fix by doubling the backslash for any
+ * escape sequence that is not recognized by YAML.
+ */
+function fixYamlBackslashes(text: string): string {
+  // Characters that are valid YAML double-quote escape sequences
+  const validYamlEscapeChars = new Set([
+    '0', 'a', 'b', 't', 'n', 'v', 'f', 'r', 'e', '"', '/', '\\', 'N', '_', 'L', 'P',
+    ' ', 'x', 'u', 'U'
+  ])
+  // Match double-quoted YAML strings, handling embedded escaped quotes
+  return text.replace(/"((?:[^"\\]|\\[\s\S])*)"/g, (match, inner: string) => {
+    const fixed = inner.replace(/\\(.)/g, (escSeq: string, c: string) => {
+      if (validYamlEscapeChars.has(c)) return escSeq
+      // Double the backslash so YAML will parse \d as literal backslash + d
+      return '\\\\' + c
+    })
+    return '"' + fixed + '"'
+  })
+}

--- a/packages/scope42-data/src/lint/index.ts
+++ b/packages/scope42-data/src/lint/index.ts
@@ -74,7 +74,11 @@ export async function lintWorkspace(
       let item: Item | null = null
 
       if (Object.keys(rawFrontmatter).length === 0) {
-        diagnostics.push({ filePath, severity: 'error', message: 'No frontmatter found' })
+        diagnostics.push({
+          filePath,
+          severity: 'error',
+          message: 'No frontmatter found'
+        })
       } else {
         const schema = SCHEMAS_BY_TYPE[type]
         const parseResult = schema.safeParse(rawFrontmatter)
@@ -88,11 +92,20 @@ export async function lintWorkspace(
             })
           }
         } else {
-          item = { id, type, frontmatter: parseResult.data, body, filePath } as Item
+          item = {
+            id,
+            type,
+            frontmatter: parseResult.data,
+            body,
+            filePath
+          } as Item
         }
       }
 
-      if (config.validation.fileNamePattern && !config.validation.fileNamePattern.test(id)) {
+      if (
+        config.validation.fileNamePattern &&
+        !config.validation.fileNamePattern.test(id)
+      ) {
         diagnostics.push({
           filePath,
           severity: 'error',
@@ -104,7 +117,11 @@ export async function lintWorkspace(
       if (headingDiag) diagnostics.push(headingDiag)
 
       if (body.trim() === '') {
-        diagnostics.push({ filePath, severity: 'warning', message: 'Empty body' })
+        diagnostics.push({
+          filePath,
+          severity: 'warning',
+          message: 'Empty body'
+        })
       }
 
       const relations = item
@@ -125,7 +142,11 @@ export async function lintWorkspace(
     const hasOutgoing = relations.length > 0
     const hasIncoming = referencedIds.has(id)
     if (!hasOutgoing && !hasIncoming) {
-      diagnostics.push({ filePath, severity: 'warning', message: 'No relations (orphaned item)' })
+      diagnostics.push({
+        filePath,
+        severity: 'warning',
+        message: 'No relations (orphaned item)'
+      })
     }
 
     for (const targetId of relations) {
@@ -145,11 +166,13 @@ export async function lintWorkspace(
 function checkHeading(body: string, filePath: string): LintDiagnostic | null {
   const firstNonBlank = body.split('\n').find(l => l.trim() !== '')
   if (!firstNonBlank) return null // empty body is a separate warning
-  if (/^#\s+\S/.test(firstNonBlank) || /^=\s+\S/.test(firstNonBlank)) return null
+  if (/^#\s+\S/.test(firstNonBlank) || /^=\s+\S/.test(firstNonBlank))
+    return null
   return {
     filePath,
     severity: 'error',
-    message: 'Body does not start with a heading (expected Markdown # or AsciiDoc =)'
+    message:
+      'Body does not start with a heading (expected Markdown # or AsciiDoc =)'
   }
 }
 
@@ -175,17 +198,23 @@ function extractRelations(item: Item, relationPattern?: RegExp): string[] {
   if (!relationPattern) return raw
   return raw.flatMap(v => {
     const match = v.match(relationPattern)
-    return match ? [match[1]] : []
+    return match && match[1] ? [match[1]] : []
   })
 }
 
-function makeFilter(include: string[], exclude: string[]): (name: string) => boolean {
+function makeFilter(
+  include: string[],
+  exclude: string[]
+): (name: string) => boolean {
   const includeMatch = picomatch(include)
   const excludeMatch = exclude.length > 0 ? picomatch(exclude) : () => false
   return name => includeMatch(name) && !excludeMatch(name)
 }
 
-async function resolveDirByPath(root: DirectoryHandle, relPath: string): Promise<DirectoryHandle> {
+async function resolveDirByPath(
+  root: DirectoryHandle,
+  relPath: string
+): Promise<DirectoryHandle> {
   const segments = relPath.split('/').filter(Boolean)
   let current = root
   for (const segment of segments) {
@@ -214,8 +243,26 @@ function stripExtension(name: string): string {
 function fixYamlBackslashes(text: string): string {
   // Characters that are valid YAML double-quote escape sequences
   const validYamlEscapeChars = new Set([
-    '0', 'a', 'b', 't', 'n', 'v', 'f', 'r', 'e', '"', '/', '\\', 'N', '_', 'L', 'P',
-    ' ', 'x', 'u', 'U'
+    '0',
+    'a',
+    'b',
+    't',
+    'n',
+    'v',
+    'f',
+    'r',
+    'e',
+    '"',
+    '/',
+    '\\',
+    'N',
+    '_',
+    'L',
+    'P',
+    ' ',
+    'x',
+    'u',
+    'U'
   ])
   // Match double-quoted YAML strings, handling embedded escaped quotes
   return text.replace(/"((?:[^"\\]|\\[\s\S])*)"/g, (match, inner: string) => {

--- a/packages/scope42-data/src/lint/lint.test.ts
+++ b/packages/scope42-data/src/lint/lint.test.ts
@@ -51,7 +51,9 @@ test('error: invalid status value', async () => {
   const result = await lintWorkspace(
     ws({
       'scope42.yaml': CFG,
-      docs: { issues: { 'issue-1.md': '---\nstatus: bogus\n---\n# Title\n\nBody.\n' } }
+      docs: {
+        issues: { 'issue-1.md': '---\nstatus: bogus\n---\n# Title\n\nBody.\n' }
+      }
     })
   )
   const errors = result.diagnostics.filter(d => d.severity === 'error')
@@ -116,7 +118,9 @@ test('no heading error for Markdown # heading', async () => {
   const result = await lintWorkspace(
     ws({ 'scope42.yaml': CFG, docs: { issues: { 'issue-1.md': issue() } } })
   )
-  expect(result.diagnostics.filter(d => d.message.includes('heading'))).toHaveLength(0)
+  expect(
+    result.diagnostics.filter(d => d.message.includes('heading'))
+  ).toHaveLength(0)
 })
 
 test('no heading error for AsciiDoc = heading', async () => {
@@ -135,7 +139,9 @@ include: ["*.adoc"]
       }
     })
   )
-  expect(result.diagnostics.filter(d => d.message.includes('heading'))).toHaveLength(0)
+  expect(
+    result.diagnostics.filter(d => d.message.includes('heading'))
+  ).toHaveLength(0)
 })
 
 // ── Relation existence ────────────────────────────────────────

--- a/packages/scope42-data/src/lint/lint.test.ts
+++ b/packages/scope42-data/src/lint/lint.test.ts
@@ -1,0 +1,218 @@
+import { lintWorkspace } from './index'
+import { VirtualDirectoryContent, VirtualDirectoryHandle } from '../io/adapters'
+
+function ws(content: VirtualDirectoryContent) {
+  return new VirtualDirectoryHandle('root', content)
+}
+
+const CFG = `
+version: 2
+items:
+  issue: docs/issues
+include: ["*.md"]
+`
+
+// A valid Markdown issue file
+function issue(extras = ''): string {
+  return `---\nstatus: current\n${extras}---\n# My Issue\n\nBody text here.\n`
+}
+
+// ── Config errors ─────────────────────────────────────────────
+
+test('throws when scope42.yaml is missing', async () => {
+  await expect(lintWorkspace(ws({}))).rejects.toThrow(/scope42\.yaml/)
+})
+
+// ── Valid item — baseline ─────────────────────────────────────
+
+test('no errors for a valid issue item', async () => {
+  const result = await lintWorkspace(
+    ws({ 'scope42.yaml': CFG, docs: { issues: { 'issue-1.md': issue() } } })
+  )
+  expect(result.diagnostics.filter(d => d.severity === 'error')).toHaveLength(0)
+})
+
+// ── Frontmatter checks ────────────────────────────────────────
+
+test('error: no frontmatter in item file', async () => {
+  const result = await lintWorkspace(
+    ws({
+      'scope42.yaml': CFG,
+      docs: { issues: { 'issue-1.md': '# Title\n\nNo frontmatter.\n' } }
+    })
+  )
+  expect(result.diagnostics).toHaveLength(1)
+  expect(result.diagnostics[0].severity).toBe('error')
+  expect(result.diagnostics[0].message).toMatch(/frontmatter/)
+  expect(result.diagnostics[0].filePath).toMatch(/issue-1\.md/)
+})
+
+test('error: invalid status value', async () => {
+  const result = await lintWorkspace(
+    ws({
+      'scope42.yaml': CFG,
+      docs: { issues: { 'issue-1.md': '---\nstatus: bogus\n---\n# Title\n\nBody.\n' } }
+    })
+  )
+  const errors = result.diagnostics.filter(d => d.severity === 'error')
+  expect(errors.length).toBeGreaterThan(0)
+  expect(errors[0].filePath).toMatch(/issue-1\.md/)
+})
+
+// ── Filename pattern ──────────────────────────────────────────
+
+test('error: filename does not match fileNamePattern', async () => {
+  const result = await lintWorkspace(
+    ws({
+      'scope42.yaml': `
+version: 2
+items:
+  issue: docs/issues
+include: ["*.md"]
+validation:
+  fileNamePattern: "issue-\\d+"
+`,
+      docs: { issues: { 'bad-name.md': issue() } }
+    })
+  )
+  const errors = result.diagnostics.filter(d => d.severity === 'error')
+  expect(errors.some(d => d.message.includes('pattern'))).toBe(true)
+})
+
+test('no error when filename matches fileNamePattern', async () => {
+  const result = await lintWorkspace(
+    ws({
+      'scope42.yaml': `
+version: 2
+items:
+  issue: docs/issues
+include: ["*.md"]
+validation:
+  fileNamePattern: "issue-\\d+"
+`,
+      docs: { issues: { 'issue-42.md': issue() } }
+    })
+  )
+  const errors = result.diagnostics.filter(d => d.severity === 'error')
+  expect(errors.some(d => d.message.includes('pattern'))).toBe(false)
+})
+
+// ── H1 heading ────────────────────────────────────────────────
+
+test('error: body does not start with a heading', async () => {
+  const result = await lintWorkspace(
+    ws({
+      'scope42.yaml': CFG,
+      docs: {
+        issues: { 'issue-1.md': '---\nstatus: current\n---\nNot a heading.\n' }
+      }
+    })
+  )
+  const errors = result.diagnostics.filter(d => d.severity === 'error')
+  expect(errors.some(d => d.message.includes('heading'))).toBe(true)
+})
+
+test('no heading error for Markdown # heading', async () => {
+  const result = await lintWorkspace(
+    ws({ 'scope42.yaml': CFG, docs: { issues: { 'issue-1.md': issue() } } })
+  )
+  expect(result.diagnostics.filter(d => d.message.includes('heading'))).toHaveLength(0)
+})
+
+test('no heading error for AsciiDoc = heading', async () => {
+  const result = await lintWorkspace(
+    ws({
+      'scope42.yaml': `
+version: 2
+items:
+  issue: docs/issues
+include: ["*.adoc"]
+`,
+      docs: {
+        issues: {
+          'issue-1.adoc': '---\nstatus: current\n---\n= My Issue\n\nBody.\n'
+        }
+      }
+    })
+  )
+  expect(result.diagnostics.filter(d => d.message.includes('heading'))).toHaveLength(0)
+})
+
+// ── Relation existence ────────────────────────────────────────
+
+test('error: relation target does not exist', async () => {
+  const result = await lintWorkspace(
+    ws({
+      'scope42.yaml': CFG,
+      docs: {
+        issues: { 'issue-1.md': issue('causedBy: ["nonexistent"]\n') }
+      }
+    })
+  )
+  const errors = result.diagnostics.filter(d => d.severity === 'error')
+  expect(errors.some(d => d.message.includes('does not exist'))).toBe(true)
+})
+
+test('no error when relation target exists', async () => {
+  const result = await lintWorkspace(
+    ws({
+      'scope42.yaml': `
+version: 2
+items:
+  issue: docs/issues
+  risk: docs/risks
+include: ["*.md"]
+`,
+      docs: {
+        issues: { 'issue-1.md': issue('causedBy: ["risk-1"]\n') },
+        risks: { 'risk-1.md': '---\nstatus: potential\n---\n# Risk\n\nBody.\n' }
+      }
+    })
+  )
+  const errors = result.diagnostics.filter(d => d.severity === 'error')
+  expect(errors.some(d => d.message.includes('does not exist'))).toBe(false)
+})
+
+// ── Warnings ──────────────────────────────────────────────────
+
+test('warning: empty body', async () => {
+  const result = await lintWorkspace(
+    ws({
+      'scope42.yaml': CFG,
+      docs: { issues: { 'issue-1.md': '---\nstatus: current\n---\n' } }
+    })
+  )
+  const warnings = result.diagnostics.filter(d => d.severity === 'warning')
+  expect(warnings.some(d => d.message.includes('Empty body'))).toBe(true)
+  // Empty body should not also produce a heading error
+  const errors = result.diagnostics.filter(d => d.severity === 'error')
+  expect(errors).toHaveLength(0)
+})
+
+test('warning: orphaned item with no relations', async () => {
+  const result = await lintWorkspace(
+    ws({ 'scope42.yaml': CFG, docs: { issues: { 'issue-1.md': issue() } } })
+  )
+  const warnings = result.diagnostics.filter(d => d.severity === 'warning')
+  expect(warnings.some(d => d.message.includes('orphaned'))).toBe(true)
+})
+
+test('no orphan warning when item has relations', async () => {
+  const result = await lintWorkspace(
+    ws({
+      'scope42.yaml': `
+version: 2
+items:
+  issue: docs/issues
+  risk: docs/risks
+include: ["*.md"]
+`,
+      docs: {
+        issues: { 'issue-1.md': issue('causedBy: ["risk-1"]\n') },
+        risks: { 'risk-1.md': '---\nstatus: potential\n---\n# Risk\n\nBody.\n' }
+      }
+    })
+  )
+  const warnings = result.diagnostics.filter(d => d.severity === 'warning')
+  expect(warnings.some(d => d.message.includes('orphaned'))).toBe(false)
+})


### PR DESCRIPTION
## Summary

- Adds new `packages/scope42-cli` package publishing the `scope42` binary with `lint` and `init` sub-commands
- Adds `lintWorkspace()` to `@scope42/data`: validates frontmatter, filename patterns, headings, relation targets, orphans, and empty bodies across all item types
- Adds `initWorkspace()` to `@scope42/data`: creates `scope42.yaml` with default config and the configured item directories
- Exposes `@scope42/data/node` as a subpath export (`NodeDirectoryHandle`) so CLI and downstream tools can import it cleanly

## Architecture

All business logic lives in `@scope42/data` (thin CLI / thick library). CLI commands use dependency injection (`DirectoryHandle` parameter + `out` callback) so they are unit-testable with `VirtualDirectoryHandle` without disk access.

Exit codes: `0` = clean, `1` = warnings only, `2` = errors or config failure.

## Test Plan

- [ ] `npm test -w packages/scope42-data` — 75 tests pass
- [ ] `npm test -w packages/scope42-cli` — 9 tests pass
- [ ] `npm run build -w packages/scope42-data && npm run build -w packages/scope42-cli` — both build cleanly
- [ ] `node packages/scope42-cli/dist/cli.js --help` — shows `scope42` with `lint` and `init` sub-commands
- [ ] `node packages/scope42-cli/dist/cli.js init --help` — shows `--force` option
- [ ] `node packages/scope42-cli/dist/cli.js lint --help` — shows `--format` option
- [ ] `scope42 init .` then `scope42 lint .` — init creates dirs, lint exits 1 (no items yet, orphan warning suppressed for empty dirs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)